### PR TITLE
Added support for Hive TRV

### DIFF
--- a/devicetypes/alyc100/hive-heating.src/hive-heating.groovy
+++ b/devicetypes/alyc100/hive-heating.src/hive-heating.groovy
@@ -257,7 +257,8 @@ def setHeatingSetpoint(temp) {
         		target: temp
         	]               
     	}
-    	def resp = parent.apiPOST("/nodes/heating/${device.deviceNetworkId}", args)    	
+        //def type = device.type;
+    	def resp = parent.apiPOST("/nodes/${device.deviceNetworkId}", args)    	
     }
     runIn(4, refresh)
 }
@@ -408,7 +409,7 @@ def setThermostatMode(mode) {
         	]
    		}
     
-    	def resp = parent.apiPOST("/nodes/heating/${device.deviceNetworkId}", args)
+    	def resp = parent.apiPOST("/nodes/${device.deviceNetworkId}", args)
 		mode = mode == 'range' ? 'auto' : mode    	
     }
     runIn(4, refresh)
@@ -445,6 +446,9 @@ def poll() {
         def temperature = currentDevice.props.temperature
         def heatingSetpoint = currentDevice.state.target as Double
         
+        log.debug "Got Temperature ${temperature} on device ${currentDevice.state.name}"
+        log.debug "Got Setpoint ${heatingSetpoint} on device ${currentDevice.state.name}"
+        
         //Check heating set point against maximum threshold value.
         log.debug "Maximum temperature threshold set to: " + getMaxTempThreshold()
         if ((getMaxTempThreshold() as BigDecimal) < (heatingSetpoint as BigDecimal))
@@ -456,7 +460,7 @@ def poll() {
         		target: getMaxTempThreshold()
             ]               
     
-    		parent.apiPOST("/nodes/heating/${device.deviceNetworkId}", args)   
+    		parent.apiPOST("/nodes/${device.deviceNetworkId}", args)   
             heatingSetpoint = String.format("%2.1f", getMaxTempThreshold())           
         }
         
@@ -481,7 +485,7 @@ def poll() {
         	def args = [
         		mode: "OFF"
             ]
-        	parent.apiPOST("/nodes/heating/${device.deviceNetworkId}", args)
+        	parent.apiPOST("/nodes/${device.deviceNetworkId}", args)
             mode = 'off'
         } 
         else if (mode == "boost") {

--- a/smartapps/alyc100/hive-connect.src/hive-connect.groovy
+++ b/smartapps/alyc100/hive-connect.src/hive-connect.groovy
@@ -60,6 +60,9 @@
  *
  *	30.10.2017
  *	v3.0 - Support for Hive Active Light Colour Tuneable device.
+ *
+ *  4.10.2019
+ *  v3.1 - Support for Hive Radiator TRV
  */
 definition(
 		name: "Hive (Connect)",
@@ -138,7 +141,7 @@ def mainPage() {
 
 def headerSECTION() {
 	return paragraph (image: "https://raw.githubusercontent.com/alyc100/SmartThingsPublic/master/smartapps/alyc100/10457773_334250273417145_3395772416845089626_n.png",
-                  "Hive (Connect)\nVersion: 3.0\nDate: 30102017(1630)")
+                  "Hive (Connect)\nVersion: 3.1\nDate: 04112019(1630)")
 }
 
 def stateTokenPresent() {
@@ -902,10 +905,11 @@ def updateDevices() {
 	devices.each { device ->
         selectors.add("${device.id}")
         //Heating
-        if (device.type == "heating") {
+        if (device.type == "heating" || device.type == "trvcontrol") {
+        	def suffix = device.type == "heating" ? "Hive Heating" : "Hive TRV"
             //Heating Control
-            log.debug "Identified: ${device.state.name} Hive Heating"
-            def value = "${device.state.name} Hive Heating"
+            log.debug "Identified: ${device.state.name} ${suffix}"
+            def value = "${device.state.name} ${suffix}"
             def key = device.id
             state.hiveHeatingDevices["${key}"] = value
 
@@ -913,8 +917,8 @@ def updateDevices() {
                 def childDevice = getChildDevice("${device.id}")
                 if (childDevice) {
                     //Update name of device if different.
-                    if(childDevice.name != device.state.name + " Hive Heating") {
-                            childDevice.name = device.state.name + " Hive Heating"
+                    if(childDevice.name != device.state.name + " ${suffix}") {
+                            childDevice.name = device.state.name + " ${suffix}"
                             log.debug "Device's name has changed."
                     }
                 }

--- a/smartapps/alyc100/hive-connect.src/hive-connect.groovy
+++ b/smartapps/alyc100/hive-connect.src/hive-connect.groovy
@@ -910,11 +910,12 @@ def updateDevices() {
             //Heating Control
             log.debug "Identified: ${device.state.name} ${suffix}"
             def value = "${device.state.name} ${suffix}"
-            def key = device.id
+            def key = device.type + "/" + device.id
+	        selectors.add("${key}")
             state.hiveHeatingDevices["${key}"] = value
 
             //Update names of devices with Hive
-                def childDevice = getChildDevice("${device.id}")
+                def childDevice = getChildDevice("${key}")
                 if (childDevice) {
                     //Update name of device if different.
                     if(childDevice.name != device.state.name + " ${suffix}") {
@@ -1199,7 +1200,7 @@ def getDeviceStatus(id) {
 	def resp = apiGET("/products")
 	if (resp.status == 200) {
 		resp.data.eachWithIndex { currentDevice, i ->
-        	if(currentDevice.id == id) { 
+        	if(currentDevice.id == id || (currentDevice.type + "/" + currentDevice.id) == id) { 
                 retVal = resp.data[i]
             }
         }


### PR DESCRIPTION
Adds support for Hive TRV. This seems to detect them, and looks like they're working. I don't *think* any driver changes are needed as the device seems to behave like a thermostat. 

Edit: turns out some driver changes were needed. The calls are to trvcontrol/deviceid rather than heating/deviceid. 

The API is exactly the same, though. So for heating and trv devices I've included the type as a prefix in the network id. 